### PR TITLE
Add Roam Python Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ rye lint
 rye lint --fix
 ```
 
+## Useful Features
+
+- Roam API SDK + Example Notebook (`notebooks/roam_api.ipynb')
+
 ## Scripts
 
 ### S3Manager

--- a/notebooks/roam_api.ipynb
+++ b/notebooks/roam_api.ipynb
@@ -1,0 +1,224 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0bfdc8c6-bc87-4831-9900-b52ae377acf2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dr_util.api_wrappers import roam_utils as ru"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cfa4fd58-b915-4247-a067-5058ebab7cd2",
+   "metadata": {},
+   "source": [
+    "Useful Docs:\n",
+    "- Write actions: [here](https://roamresearch.com/#/app/developer-documentation/page/IEmaIxzTU)\n",
+    "- Pull Actions: [here](https://roamresearch.com/#/app/developer-documentation/page/hVxZlW31i)\n",
+    "- ...with extra pattern info: [here](https://docs.datomic.com/query/query-pull.html)\n",
+    "- Then extend to pull many: [here](https://roamresearch.com/#/app/developer-documentation/page/UAK4JsX9y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ebed63b4-89f1-4323-baec-ae52c853e2b3",
+   "metadata": {},
+   "source": [
+    "## Create the Client\n",
+    "TODO: don't commit the token"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "65fb343a-bd1c-4ecb-8b2d-6f31c552f978",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = ru.RoamBackendClient(\n",
+    "  token='roam-graph-token-m84asuuLkJzT7i19JS6SX00ILBI9r',\n",
+    "  graph='life_planning',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fae72f60-9e5c-46d8-93f0-58cf5156493f",
+   "metadata": {},
+   "source": [
+    "## Pull Request\n",
+    "Get the page with all of its children and references."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8f3bcd1d-7cca-4492-ad4e-bebf7760ceee",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{':node/title': 'October 5th, 2024',\n",
+       " ':block/children': [{':block/uid': '8iuuk1sRN',\n",
+       "   ':block/string': \"Can I get the data that's in this block\"}],\n",
+       " ':block/uid': '10-05-2024'}"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ru.pull(\n",
+    "  client,\n",
+    "  pattern=\"[:block/uid :node/title :block/string {:block/children [:block/uid :block/string]} {:block/refs [:node/title :block/string :block/uid]}]\", \n",
+    "  eid=\"[:block/uid \\\"10-05-2024\\\"]\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d42e5d25-27e8-43bb-8960-2aa016e60200",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pull_res = ru.pull(\n",
+    "  client,\n",
+    "  eid=\"[:block/uid \\\"10-05-2024\\\"]\",\n",
+    "  pattern=\"[:block/uid :node/title :block/string {:block/refs [:node/title :block/string :block/uid]} {:block/children ...}]\", \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "4aa04ea4-2ce7-4d24-9b0c-7490bfc31a8b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{':block/refs': [{':node/title': \"Today's Progress\",\n",
+       "   ':block/uid': 'VfYS0XB_O'}],\n",
+       " ':block/uid': 'FdQAgW3nY',\n",
+       " ':block/string': \"[[Today's Progress]]\"}"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pull_res[':block/children'][0][':block/children'][0][':block/children'][0][':block/children'][0][':block/children'][0][':block/children'][0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "e5dbf85d-7266-400a-bf1e-9bab83275b90",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"Can I get the data that's in this block\""
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pull_res[':block/children'][0][':block/string']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "f93e5935-8302-4944-b95e-078e83e864b8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'8iuuk1sRN'"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pull_res[':block/children'][0][':block/uid']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e17651da-9f59-4fc2-9a17-9944ba0c762b",
+   "metadata": {},
+   "source": [
+    "## Write to a block\n",
+    "This worked!!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "eba04442-d90f-47b5-ac91-d9c064b28356",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "200"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ru.update_block(\n",
+    "    client,\n",
+    "    body={\n",
+    "        'block': {\n",
+    "            \"uid\": pull_res[':block/children'][0][':block/uid'],\n",
+    "            \"string\": \"can we overwrite this??\",\n",
+    "        },\n",
+    "    },\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ build-backend = "hatchling.build"
 managed = true
 dev-dependencies = [
     "pytest>=8.1.1",
+    "jupyterlab>=4.2.5",
+    "jupyterlab-vim>=4.1.4",
 ]
 
 [tool.rye.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "omegaconf>=2.3.0",
     "boto3>=1.35.20",
     "hydra-core==1.3",
-    "requests==2.28.1",
+    "requests==2.31",
     "schema>=0.7.7",
 ]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ dependencies = [
     "omegaconf>=2.3.0",
     "boto3>=1.35.20",
     "hydra-core==1.3",
+    "requests==2.28.1",
+    "schema>=0.7.7",
 ]
 readme = "README.md"
 requires-python = ">= 3.8"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -43,8 +43,6 @@ boto3==1.35.20
 botocore==1.35.20
     # via boto3
     # via s3transfer
-hydra-core==1.3.0
-    # via dr-util
 certifi==2024.8.30
     # via httpcore
     # via httpx
@@ -73,6 +71,8 @@ httpcore==1.0.6
     # via httpx
 httpx==0.27.2
     # via jupyterlab
+hydra-core==1.3.0
+    # via dr-util
 idna==3.10
     # via anyio
     # via httpx
@@ -164,6 +164,7 @@ numpy==1.26.4
     # via dr-util
 omegaconf==2.3.0
     # via dr-util
+    # via hydra-core
 overrides==7.7.0
     # via jupyter-server
 packaging==24.0

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -52,7 +52,7 @@ python-dateutil==2.9.0.post0
     # via botocore
 pyyaml==6.0.1
     # via omegaconf
-requests==2.28.1
+requests==2.31.0
     # via dr-util
 s3transfer==0.10.2
     # via boto3

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -22,6 +22,12 @@ botocore==1.35.20
     # via s3transfer
 hydra-core==1.3.0
     # via dr-util
+certifi==2024.8.30
+    # via requests
+charset-normalizer==2.1.1
+    # via requests
+idna==3.10
+    # via requests
 iniconfig==2.0.0
     # via pytest
 jmespath==1.0.1
@@ -46,9 +52,14 @@ python-dateutil==2.9.0.post0
     # via botocore
 pyyaml==6.0.1
     # via omegaconf
+requests==2.28.1
+    # via dr-util
 s3transfer==0.10.2
     # via boto3
+schema==0.7.7
+    # via dr-util
 six==1.16.0
     # via python-dateutil
-urllib3==2.2.3
+urllib3==1.26.20
     # via botocore
+    # via requests

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -13,8 +13,31 @@
 antlr4-python3-runtime==4.9.3
     # via hydra-core
     # via omegaconf
+anyio==4.6.0
+    # via httpx
+    # via jupyter-server
+appnope==0.1.4
+    # via ipykernel
+argon2-cffi==23.1.0
+    # via jupyter-server
+argon2-cffi-bindings==21.2.0
+    # via argon2-cffi
+arrow==1.3.0
+    # via isoduration
+asttokens==2.4.1
+    # via stack-data
+async-lru==2.0.4
+    # via jupyterlab
 attrs==23.2.0
     # via jsonlines
+    # via jsonschema
+    # via referencing
+babel==2.16.0
+    # via jupyterlab-server
+beautifulsoup4==4.12.3
+    # via nbconvert
+bleach==6.1.0
+    # via nbconvert
 boto3==1.35.20
     # via dr-util
 botocore==1.35.20
@@ -23,43 +46,247 @@ botocore==1.35.20
 hydra-core==1.3.0
     # via dr-util
 certifi==2024.8.30
+    # via httpcore
+    # via httpx
     # via requests
+cffi==1.17.1
+    # via argon2-cffi-bindings
 charset-normalizer==2.1.1
     # via requests
+comm==0.2.2
+    # via ipykernel
+debugpy==1.8.6
+    # via ipykernel
+decorator==5.1.1
+    # via ipython
+defusedxml==0.7.1
+    # via nbconvert
+executing==2.1.0
+    # via stack-data
+fastjsonschema==2.20.0
+    # via nbformat
+fqdn==1.5.1
+    # via jsonschema
+h11==0.14.0
+    # via httpcore
+httpcore==1.0.6
+    # via httpx
+httpx==0.27.2
+    # via jupyterlab
 idna==3.10
+    # via anyio
+    # via httpx
+    # via jsonschema
     # via requests
 iniconfig==2.0.0
     # via pytest
+ipykernel==6.29.5
+    # via jupyterlab
+ipython==8.28.0
+    # via ipykernel
+isoduration==20.11.0
+    # via jsonschema
+jedi==0.19.1
+    # via ipython
+jinja2==3.1.4
+    # via jupyter-server
+    # via jupyterlab
+    # via jupyterlab-server
+    # via nbconvert
 jmespath==1.0.1
     # via boto3
     # via botocore
+json5==0.9.25
+    # via jupyterlab-server
 jsonlines==4.0.0
     # via dr-util
+jsonpointer==3.0.0
+    # via jsonschema
+jsonschema==4.23.0
+    # via jupyter-events
+    # via jupyterlab-server
+    # via nbformat
+jsonschema-specifications==2023.12.1
+    # via jsonschema
+jupyter-client==8.6.3
+    # via ipykernel
+    # via jupyter-server
+    # via nbclient
+jupyter-core==5.7.2
+    # via ipykernel
+    # via jupyter-client
+    # via jupyter-server
+    # via jupyterlab
+    # via nbclient
+    # via nbconvert
+    # via nbformat
+jupyter-events==0.10.0
+    # via jupyter-server
+jupyter-lsp==2.2.5
+    # via jupyterlab
+jupyter-server==2.14.2
+    # via jupyter-lsp
+    # via jupyterlab
+    # via jupyterlab-server
+    # via notebook-shim
+jupyter-server-terminals==0.5.3
+    # via jupyter-server
+jupyterlab==4.2.5
+    # via jupyterlab-vim
+jupyterlab-pygments==0.3.0
+    # via nbconvert
+jupyterlab-server==2.27.3
+    # via jupyterlab
+jupyterlab-vim==4.1.4
 loguru==0.7.2
     # via dr-util
+markupsafe==2.1.5
+    # via jinja2
+    # via nbconvert
+matplotlib-inline==0.1.7
+    # via ipykernel
+    # via ipython
+mistune==3.0.2
+    # via nbconvert
+nbclient==0.10.0
+    # via nbconvert
+nbconvert==7.16.4
+    # via jupyter-server
+nbformat==5.10.4
+    # via jupyter-server
+    # via nbclient
+    # via nbconvert
+nest-asyncio==1.6.0
+    # via ipykernel
+notebook-shim==0.2.4
+    # via jupyterlab
 numpy==1.26.4
     # via dr-util
 omegaconf==2.3.0
     # via dr-util
-    # via hydra-core
+overrides==7.7.0
+    # via jupyter-server
 packaging==24.0
     # via hydra-core
+    # via ipykernel
+    # via jupyter-server
+    # via jupyterlab
+    # via jupyterlab-server
+    # via nbconvert
     # via pytest
+pandocfilters==1.5.1
+    # via nbconvert
+parso==0.8.4
+    # via jedi
+pexpect==4.9.0
+    # via ipython
+platformdirs==4.3.6
+    # via jupyter-core
 pluggy==1.5.0
     # via pytest
+prometheus-client==0.21.0
+    # via jupyter-server
+prompt-toolkit==3.0.48
+    # via ipython
+psutil==6.0.0
+    # via ipykernel
+ptyprocess==0.7.0
+    # via pexpect
+    # via terminado
+pure-eval==0.2.3
+    # via stack-data
+pycparser==2.22
+    # via cffi
+pygments==2.18.0
+    # via ipython
+    # via nbconvert
 pytest==8.1.1
 python-dateutil==2.9.0.post0
+    # via arrow
     # via botocore
+    # via jupyter-client
+python-json-logger==2.0.7
+    # via jupyter-events
 pyyaml==6.0.1
+    # via jupyter-events
     # via omegaconf
+pyzmq==26.2.0
+    # via ipykernel
+    # via jupyter-client
+    # via jupyter-server
+referencing==0.35.1
+    # via jsonschema
+    # via jsonschema-specifications
+    # via jupyter-events
 requests==2.31.0
     # via dr-util
+    # via jupyterlab-server
+rfc3339-validator==0.1.4
+    # via jsonschema
+    # via jupyter-events
+rfc3986-validator==0.1.1
+    # via jsonschema
+    # via jupyter-events
+rpds-py==0.20.0
+    # via jsonschema
+    # via referencing
 s3transfer==0.10.2
     # via boto3
 schema==0.7.7
     # via dr-util
+send2trash==1.8.3
+    # via jupyter-server
+setuptools==75.1.0
+    # via jupyterlab
 six==1.16.0
+    # via asttokens
+    # via bleach
     # via python-dateutil
+    # via rfc3339-validator
+sniffio==1.3.1
+    # via anyio
+    # via httpx
+soupsieve==2.6
+    # via beautifulsoup4
+stack-data==0.6.3
+    # via ipython
+terminado==0.18.1
+    # via jupyter-server
+    # via jupyter-server-terminals
+tinycss2==1.3.0
+    # via nbconvert
+tornado==6.4.1
+    # via ipykernel
+    # via jupyter-client
+    # via jupyter-server
+    # via jupyterlab
+    # via terminado
+traitlets==5.14.3
+    # via comm
+    # via ipykernel
+    # via ipython
+    # via jupyter-client
+    # via jupyter-core
+    # via jupyter-events
+    # via jupyter-server
+    # via jupyterlab
+    # via matplotlib-inline
+    # via nbclient
+    # via nbconvert
+    # via nbformat
+types-python-dateutil==2.9.0.20241003
+    # via arrow
+uri-template==1.3.0
+    # via jsonschema
 urllib3==1.26.20
     # via botocore
     # via requests
+wcwidth==0.2.13
+    # via prompt-toolkit
+webcolors==24.8.0
+    # via jsonschema
+webencodings==0.5.1
+    # via bleach
+    # via tinycss2
+websocket-client==1.8.0
+    # via jupyter-server

--- a/requirements.lock
+++ b/requirements.lock
@@ -20,12 +20,12 @@ boto3==1.35.20
 botocore==1.35.20
     # via boto3
     # via s3transfer
-hydra-core==1.3.0
-    # via dr-util
 certifi==2024.8.30
     # via requests
 charset-normalizer==2.1.1
     # via requests
+hydra-core==1.3.0
+    # via dr-util
 idna==3.10
     # via requests
 jmespath==1.0.1

--- a/requirements.lock
+++ b/requirements.lock
@@ -22,6 +22,12 @@ botocore==1.35.20
     # via s3transfer
 hydra-core==1.3.0
     # via dr-util
+certifi==2024.8.30
+    # via requests
+charset-normalizer==2.1.1
+    # via requests
+idna==3.10
+    # via requests
 jmespath==1.0.1
     # via boto3
     # via botocore
@@ -40,9 +46,14 @@ python-dateutil==2.9.0.post0
     # via botocore
 pyyaml==6.0.1
     # via omegaconf
+requests==2.28.1
+    # via dr-util
 s3transfer==0.10.2
     # via boto3
+schema==0.7.7
+    # via dr-util
 six==1.16.0
     # via python-dateutil
-urllib3==2.2.3
+urllib3==1.26.20
     # via botocore
+    # via requests

--- a/requirements.lock
+++ b/requirements.lock
@@ -46,7 +46,7 @@ python-dateutil==2.9.0.post0
     # via botocore
 pyyaml==6.0.1
     # via omegaconf
-requests==2.28.1
+requests==2.31.0
     # via dr-util
 s3transfer==0.10.2
     # via boto3

--- a/src/dr_util/api_wrappers/roam_utils.py
+++ b/src/dr_util/api_wrappers/roam_utils.py
@@ -1,0 +1,134 @@
+# Copied and adapated from: https://github.com/Roam-Research/backend-sdks/blob/master/python/roam_client/client.py
+
+import requests
+import json
+import re
+from schema import Schema, Or, And, Use, Optional, SchemaError
+
+class RoamBackendClient:
+    def __init__(self, token, graph):
+        self.__token = token
+        self.graph = graph
+        self.__cache = {}
+
+    def __make_request(self, path, body, method = None):
+        method = 'POST' if method is None else method
+        if self.graph in self.__cache:
+            base_url = self.__cache[self.graph]
+        else:
+            base_url = 'https://api.roamresearch.com'
+        return (base_url + path, method, {'Content-Type': 'application/json; charset=utf-8', 'Authorization': 'Bearer ' + self.__token, 'x-authorization': 'Bearer ' + self.__token })
+
+    def call(self, path, method, body):
+        url, method, headers = self.__make_request(path, body, method)
+        resp = requests.post(url, headers=headers, json=body, allow_redirects=False)
+        if resp.is_redirect or resp.is_permanent_redirect:
+            if 'Location' in resp.headers:
+                mtch = re.search(r'https://(peer-\d+).*?:(\d+).*', resp.headers['Location'])
+                if mtch is None:
+                    raise Exception('TODO')
+                peer_n, port = mtch.groups()
+                self.__cache[self.graph] = redirect_url = 'https://' + peer_n + '.api.roamresearch.com:' + port
+                return self.call(path, method, body)
+            else:
+                raise Exception('TODO')
+        if not resp.ok:
+            print(resp.status_code)
+            if resp.status_code == 500:
+                raise Exception('Error (HTTP 500): ' + str(resp.json()))
+            elif resp.status_code == 400:
+                raise Exception('Error (HTTP 400): ' + str(resp.json()))
+            elif resp.status_code == 401:
+                raise Exception("Invalid token or token doesn't have enough privileges.")
+            else:
+                raise Exception('Error (HTTP 503): Your graph is not ready yet for a request, please retry in a few seconds.')
+        return resp
+
+def q(client: RoamBackendClient, query: str, args = None):
+    path = '/api/graph/' + client.graph + '/q'
+    body = {'query': query}
+    if args is not None:
+        body['args'] = args
+    resp = client.call(path, 'POST', body)
+    result = resp.json()
+    return result['result']
+
+def pull(client: RoamBackendClient, pattern: str, eid: str):
+    path = '/api/graph/' + client.graph + '/pull'
+    body = {'eid': eid, 'selector': pattern}
+    resp = client.call(path, 'POST', body)
+    result = resp.json()
+    return result['result']
+
+def pull_many(client: RoamBackendClient, pattern: str, eids: str):
+    path = '/api/graph/' + client.graph + '/pull-many'
+    body = {'eids': eids, 'selector': pattern}
+    resp = client.call(path, 'POST', body)
+    result = resp.json()
+    return result['result']
+
+roam_block_location = Schema({'parent-uid': str, 'order': Or(int, str)})
+
+roam_block = Schema({'string': str, Optional('uid'): str, Optional('open'): bool, Optional('heading'): int, Optional('text-align'): bool, Optional('children-view-type'): str})
+
+roam_create_block = Schema({Optional('action'): And(str, lambda s: s=='create-block'), 'location': roam_block_location, 'block': roam_block})
+
+def create_block(client: RoamBackendClient, body):
+    body['action'] = 'create-block'
+    path = '/api/graph/' + client.graph + '/write'
+    resp = client.call(path, 'POST', roam_create_block.validate(body))
+    return resp.status_code
+
+roam_move_block = Schema({Optional('action'): And(str, lambda s: s=='move-block'), 'location': roam_block_location, 'block': {'uid': str}})
+
+def move_block(client: RoamBackendClient, body):
+    body['action'] = 'move-block'
+    path = '/api/graph/' + client.graph + '/write'
+    resp = client.call(path, 'POST', roam_move_block.validate(body))
+    return resp.status_code
+
+roam_update_block = Schema({Optional('action'): And(str, lambda s: s=='update-block'), 'block': {Optional('string'): str, 'uid': str, Optional('open'): bool, Optional('heading'): int, Optional('text-align'): bool, Optional('children-view-type'): str}})
+
+def update_block(client: RoamBackendClient, body):
+    body['action'] = 'update-block'
+    path = '/api/graph/' + client.graph + '/write'
+    resp = client.call(path, 'POST', roam_update_block.validate(body))
+    return resp.status_code
+
+roam_delete_block = Schema({Optional('action'): And(str, lambda s: s=='delete-block'), 'block': {'uid': str}})
+
+def delete_block(client: RoamBackendClient, body):
+    body['action'] = 'delete-block'
+    path = '/api/graph/' + client.graph + '/write'
+    resp = client.call(path, 'POST', roam_delete_block.validate(body))
+    return resp.status_code
+
+roam_create_page = Schema({Optional('action'): And(str, lambda s: s=='create-page'), 'page': {Optional('uid'): str, 'title': str, Optional('children-view-type'): str}})
+
+def create_page(client: RoamBackendClient, body):
+    body['action'] = 'create-page'
+    path = '/api/graph/' + client.graph + '/write'
+    resp = client.call(path, 'POST', roam_create_page.validate(body))
+    return resp.status_code
+
+roam_update_page = Schema({Optional('action'): And(str, lambda s: s=='update-page'), 'page': {'uid': str, Optional('title'): str, Optional('children-view-type'): str}})
+
+def update_page(client: RoamBackendClient, body):
+    body['action'] = 'update-page'
+    path = '/api/graph/' + client.graph + '/write'
+    resp = client.call(path, 'POST', roam_update_page.validate(body))
+    return resp.status_code
+
+roam_delete_page = Schema({Optional('action'): And(str, lambda s: s=='delete-page'), 'page': {'uid': str}})
+
+def delete_page(client: RoamBackendClient, body):
+    body['action'] = 'delete-page'
+    path = '/api/graph/' + client.graph + '/write'
+    resp = client.call(path, 'POST', roam_delete_page.validate(body))
+    return resp.status_code
+
+init_graph = Schema({'graph': str, 'token': str})
+
+def initialize_graph(inp):
+    init_graph.validate(inp)
+    return RoamBackendClient(inp['token'], inp['graph'])


### PR DESCRIPTION
Roam has an awesome backend api (see [here](https://roamresearch.com/#/app/developer-documentation/page/W4Po8pcHQ)) and then a great developer kit with a variety of clients including python in this repo: https://github.com/Roam-Research/backend-sdks

However, you can't directly install the python sdk from the url because it's nested. Instead I'm copying it with attribution into this repo so I can modify it as I want.

Added to: `api_wrappers/roam_client.py`

Then tested + documented in: `notebooks/roam_sdk.ipynb`

**Future goal:** write helpers to wrap the api calls with our standard usage like full page queries.