### PR TITLE
Update file_utils help strings

### DIFF
--- a/src/dr_util/file_utils.py
+++ b/src/dr_util/file_utils.py
@@ -10,24 +10,33 @@ import numpy as np
 from omegaconf import OmegaConf
 
 
-def help():
+def fu_help():
     buff = io.StringIO()
-    buff.write("\n :: Help for dr_util.file_utils ::\n\n")
+    title_str = ":: Help for dr_util.file_utils ::"
+    block_str = f" {'-'*len(title_str)} \n"
 
-    buff.write(">> For pathlib helpers: fu.pathlib_help()\n\n")
+    buff.write(f"\n{title_str}\n")
+    buff.write(f"{block_str}\n")
+    buff.write(" For pathlib helpers: fu.pathlib_help()\n\n")
+    buff.write(" Main Functions\n")
+    buff.write("  - load_file(path, force_suffix=None, mmm=None, *, verbose=True)\n")
+    buff.write("  - dump_file(data, path, force_suffix=None, verbose=Tue)\n")
+    buff.write("  - load_files(path_list)\n\n")
+    buff.write(" Supported Endings: json, jsonl, pkl, txt, npy, yaml\n")
+    buff.write(f"\n{block_str}")
 
-    buff.write(">> Main Functions\n")
-    buff.write(" - load_file(path, force_suffix=None, mmm=None, *, verbose=True)\n")
-    buff.write(" - dump_file(data, path, force_suffix=None, verbose=Tue)\n")
-    buff.write(" - load_files(path_list)\n\n")
-
-    buff.write(">> Supported Endings: json, jsonl, pkl, txt, npy, yaml\n")
     buff_str = buff.getvalue()
-    print(buff_str)
+    logging.info(buff_str)
     return buff_str
 
 
 def pathlib_help():
+    buff = io.StringIO()
+    title_str = ":: Useful Standard Pathlib Methods ::"
+    block_str = f" {'-'*len(title_str)} \n"
+    buff.write(f"\n{title_str}\n")
+    buff.write(f"{block_str}\n")
+
     import_str = "import pathlib"
     path_props = [
         'p = pathlib.Path("/etc/a/b/d.json")' "p.name = d.json",
@@ -72,17 +81,19 @@ def pathlib_help():
             "touch()",
         ],
     ]
-    ss = io.StringIO()
-    ss.write("\n\n:: Useful Standard Lib Methods ::\n")
-    ss.write(f'{"-" * 50}\n')
-    ss.write(f"{import_str}\n")
-    for st in [f" - {p}\n" for p in (*path_props, *construct_paths, *nav_dirs)]:
-        ss.write(st)
-    ss.write("Methods:\n")
+
+    buff.write(f" {import_str}\n")
+    for st in [f"  - {p}\n" for p in (*path_props, *construct_paths, *nav_dirs)]:
+        buff.write(st)
+    buff.write("\n Methods:\n")
     for mg in path_mthds:
         mm = ", ".join(mg)
-        ss.write(f"  {mm}\n")
-    return ss.getvalue()
+        buff.write(f"   {mm}\n")
+    buff.write(f"\n{block_str}")
+
+    buff_str = buff.getvalue()
+    logging.info(buff_str)
+    return buff_str
 
 
 def load_files(path_list):
@@ -199,4 +210,5 @@ if __name__ == "__main__":
 
     logger.remove()
     logger.add(sys.stdout, format="{time} | {message}", colorize=True)
-    logger.info(help_str())
+    fu_help()
+    pathlib_help()

--- a/src/dr_util/file_utils.py
+++ b/src/dr_util/file_utils.py
@@ -10,7 +10,24 @@ import numpy as np
 from omegaconf import OmegaConf
 
 
-def help_str():
+def help():
+    buff = io.StringIO()
+    buff.write("\n :: Help for dr_util.file_utils ::\n\n")
+
+    buff.write(">> For pathlib helpers: fu.pathlib_help()\n\n")
+
+    buff.write(">> Main Functions\n")
+    buff.write(" - load_file(path, force_suffix=None, mmm=None, *, verbose=True)\n")
+    buff.write(" - dump_file(data, path, force_suffix=None, verbose=Tue)\n")
+    buff.write(" - load_files(path_list)\n\n")
+
+    buff.write(">> Supported Endings: json, jsonl, pkl, txt, npy, yaml\n")
+    buff_str = buff.getvalue()
+    print(buff_str)
+    return buff_str
+
+
+def pathlib_help():
     import_str = "import pathlib"
     path_props = [
         'p = pathlib.Path("/etc/a/b/d.json")' "p.name = d.json",

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -14,7 +14,7 @@ sample_data = {
 
 
 def test_help():
-    helps = fu.help()
+    helps = fu.fu_help()
     assert helps != ""
 
     pathlib_helps = fu.pathlib_help()

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -14,8 +14,11 @@ sample_data = {
 
 
 def test_help():
-    helps = fu.help_str()
+    helps = fu.help()
     assert helps != ""
+
+    pathlib_helps = fu.pathlib_help()
+    assert pathlib_helps != ""
 
 
 @pytest.mark.parametrize("file_format", ["json", "jsonl", "pkl", "txt", "npy", "yaml"])


### PR DESCRIPTION
Updated file utils help strings:
- made the command names easier to remember
- updated the formatting of the help strings
- added a file_utils specific one that lists the main fxns available

`rye fmt`, `rye lint --fix`, `rye test` passed.

## Help String Outputs

After importing file utils: `import dr_util.file_utils as fu`

File Utils Help String
```
>>> print(fu.fu_help())

:: Help for dr_util.file_utils ::
 ---------------------------------

 For pathlib helpers: fu.pathlib_help()

 Main Functions
  - load_file(path, force_suffix=None, mmm=None, *, verbose=True)
  - dump_file(data, path, force_suffix=None, verbose=Tue)
  - load_files(path_list)

 Supported Endings: json, jsonl, pkl, txt, npy, yaml

 ---------------------------------

```

Pathlib Help String
```
>>> print(fu.pathlib_help())

:: Useful Standard Pathlib Methods ::
 -------------------------------------

 import pathlib
  - p = pathlib.Path("/etc/a/b/d.json")p.name = d.json
  - p.suffix = .json
  - p.parent = b
  - p.parents = [/etc/a/b, /etc/a, /etc]
  - p.stem = d, Path("a.tar.gz").stem = a.tar
  - p.is_absolute() = True
  - p.is_relative_to("/usr") = False
  - p.exists() = True
  - p.with_name("df.zip") = /etc/a/df.zip
  - p.with_stem("ab") = /etc/a/ab.zip
  - p.with_suffix(".zip") = /etc/a/b.zip
  - p / "init.d" = /etc/a/b.zip/init.d
  - [x for x in p.iterdir() if p.is_dir()]
  - list(p.glob("**/*.py")
  - with p.open() as f: f.readline()

 Methods:
   cwd(), home(), exists(p), expanduser(), is_file(), is_dir()
   is_symlink(), mkdir(parents=False, exists_ok=False), rename(new_path_obj)
   absolute(), resolve(), rglob(), rmdir(), touch()

 -------------------------------------

```